### PR TITLE
detect selection if it contains last measure

### DIFF
--- a/notenames.qml
+++ b/notenames.qml
@@ -116,16 +116,28 @@ MuseScore {
          Qt.quit();
 
       var cursor     = curScore.newCursor();
+      var startStaff;
+      var endStaff;
+      var endTick;
+      var fullScore = false;
       cursor.rewind(1);
-      var startStaff = cursor.staffIdx;
-      cursor.rewind(2);
-      var endStaff   = cursor.staffIdx;
-      var endTick    = cursor.tick; // if no selection, end of score
-      var fullScore  = false;
       if (!cursor.segment) { // no selection
-         fullScore   = true;
-         startStaff  = 0; // start with 1st staff
-         endStaff    = curScore.nstaves - 1; // and end with last
+            fullScore = true;
+            startStaff = 0; // start with 1st staff
+            endStaff  = curScore.nstaves - 1; // and end with last
+      } else {
+            startStaff = cursor.staffIdx;
+            cursor.rewind(2);
+            if (cursor.tick == 0) {
+                  // this happens when the selection includes
+                  // the last measure of the score.
+                  // rewind(2) goes behind the last segment (where
+                  // there's none) and sets tick=0
+                  endTick = curScore.lastSegment.tick + 1;
+            } else {
+                  endTick = cursor.tick;
+            }
+            endStaff   = cursor.staffIdx;
       }
       console.log(startStaff + " - " + endStaff + " - " + endTick)
 


### PR DESCRIPTION
If the selection includes the last measure, it wasn't detected, because rewind(2) sets the cursor behind the end of the score. Thus cursor.segment == null.

For a demonstration:
1) Open some file (at least 2 measures).
2) Select only the whole last measure.
3) Run the plugin. It will write the names on all notes because it didn't identify the selection correctly.
